### PR TITLE
Add disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # klima-playgrounds
 Deployment of Playgrounds application for Klima DAO
+
+# Local Development with Docker
+
+To run a local development environment using Docker, follow these steps.
+
+1. `docker run -v $PWD:/usr/local/src -it -p 8050:8050 -w /usr/local/src python:3.9 bash`
+2. `pip install -r requirements.txt`
+3. `python index.py`
+
+You should now be able to access your local development version of the site at
+`http://localhost:8050`
+
+_NOTE: since your local copy of the code is mounted in the container,_
+_any changes will be automatically reflected when you reload the page._

--- a/apps/disclaimerPage.py
+++ b/apps/disclaimerPage.py
@@ -1,0 +1,10 @@
+import dash
+import dash_bootstrap_components as dbc
+
+from components.disclaimer import long_disclaimer_row
+
+app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+
+layout = dbc.Container([
+    long_disclaimer_row()
+])

--- a/apps/homePage.py
+++ b/apps/homePage.py
@@ -3,6 +3,8 @@ import dash_bootstrap_components as dbc  # pip install dash-bootstrap-components
 from dash import html
 import dash_extensions as de  # pip install dash-extensions
 
+from components.disclaimer import short_disclaimer_row
+
 url = "https://assets6.lottiefiles.com/packages/lf20_0ac4xdrp.json"
 options = dict(loop=True, autoplay=True, rendererSettings=dict(preserveAspectRatio='xMidYMid slice'))
 
@@ -52,5 +54,6 @@ layout = dbc.Container([
                 ])
             ], style={'textAlign': 'center', 'height': '100%'})
         ], style={'padding': '10px'}, xs=12, sm=12, md=12, lg=6, xl=6)
-    ])
+    ]),
+    short_disclaimer_row()
 ])

--- a/apps/playgroundSimulation_KlimaGrowthOverTime.py
+++ b/apps/playgroundSimulation_KlimaGrowthOverTime.py
@@ -10,6 +10,8 @@ import math
 from millify import millify
 from app import app
 
+from components.disclaimer import short_disclaimer_row
+
 # Build the layout for the app. Using dash bootstrap container here instead of the standard html div.
 # Container looks better
 layout = dbc.Container([
@@ -513,6 +515,7 @@ layout = dbc.Container([
                                                  'padding': '10px'}))])
                 ])
     ], className='mb-4'),
+    short_disclaimer_row()
 ], fluid=True)  # Responsive ui control
 
 

--- a/apps/playgroundsSimulation_KlimaBonding.py
+++ b/apps/playgroundsSimulation_KlimaBonding.py
@@ -1,4 +1,3 @@
-# Import all required packages for this page
 from dash import dcc
 import dash_bootstrap_components as dbc
 from dash import html
@@ -6,7 +5,9 @@ from dash.dependencies import Input, Output
 import plotly.graph_objects as go
 import pandas as pd
 import numpy as np
+
 from app import app
+from components.disclaimer import short_disclaimer_row
 
 # Build the layout for the app. Using dash bootstrap container here instead of the standard html div.
 # Container looks better
@@ -231,6 +232,7 @@ layout = dbc.Container([
                                                  'padding': '10px'}))])
                 ])
     ], className='mb-4'),
+    short_disclaimer_row()
 ], fluid=True)  # Responsive ui control
 
 

--- a/components/disclaimer.py
+++ b/components/disclaimer.py
@@ -1,0 +1,81 @@
+import dash_bootstrap_components as dbc
+from dash import html
+
+from config import PROTOCOL
+
+SHORT_DISCLAIMER = (
+    f"{PROTOCOL} Playgrounds is for educational purposes only and is not an individualized "
+    f"recommendation. Further {PROTOCOL} Playgrounds are an educational tool and should "
+    f"not be relied upon as the primary basis for investment, financial, tax-planning, "
+    f"or retirement decisions. These metrics are not tailored to the investment objectives "
+    f"of a specific user. This educational information neither is, nor should be construed as, "
+    f"investment advice, financial guidance or an offer or a solicitation or recommendation "
+    f"to buy, sell, or hold any security, or to engage in any specific investment strategy by "
+    f"{PROTOCOL} Playgrounds. These metrics used herein may change at any time and {PROTOCOL} "
+    f"Playgrounds will not notify you when such changes are made. You are responsible for "
+    f"doing your own diligence at all times."
+)
+
+LONG_DISCLAIMER = [
+    html.P(
+        f"{PROTOCOL} Playgrounds is for educational purposes only and is not an individualized recommendation. "
+        f"Further, {PROTOCOL} Playgrounds is an educational tool and should not be relied upon as the primary basis "
+        f"for investment, financial, tax-planning, or retirement decisions. These metrics are not tailored to the "
+        f"investment objectives of a specific user. This educational information neither is, nor should be construed "
+        f"as, investment advice, financial guidance or an offer or a solicitation or recommendation to buy, sell, "
+        f"or hold any security, or to engage in any specific investment strategy by {PROTOCOL} Playgrounds. "
+        f"These metrics used herein may change at any time and {PROTOCOL} Playgrounds will not notify you when "
+        f"such changes are made."
+    ),
+    html.P(
+        "You are responsible for doing your own diligence at all times."
+    ),
+    html.P(
+        f"{PROTOCOL} Playgrounds does not take into account nor does it provide any tax, legal or investment advice or "
+        f"opinion regarding the specific investment objectives or financial situation of any person. "
+        f"{PROTOCOL} Playgrounds and its developers, related DAO members, agents, advisors, directors, officers, "
+        f"contractors and token holders make no representation or warranties, expressed or implied, as to the "
+        f"accuracy of such information and {PROTOCOL} Playgrounds expressly disclaims any and all liability that "
+        f"may be based on such information or errors or omissions thereof. [{PROTOCOL} Playgrounds reserves the "
+        f"right to amend or replace the information contained herein, in part or entirely, at any time, and "
+        f"undertakes no obligation to provide the recipient with access to the amended information or to notify "
+        f"the recipient thereof. Any information, representations or statements not contained herein shall not "
+        f"be relied upon for any purpose."
+    ),
+    html.P(
+        f"Neither {PROTOCOL}DAO nor {PROTOCOL} Playgrounds, nor any of its representatives, shall have any liability "
+        f"whatsoever, under contract, tort, trust or otherwise, to you or any person resulting from the use of "
+        f"the information in {PROTOCOL} Playgrounds by you or any of your representatives or for omissions from "
+        f"the information in {PROTOCOL} Playgrounds."
+    ),
+    html.P(
+        f"Additionally, the {PROTOCOL} Playgrounds undertakes no obligation to comment on the expectations of, "
+        f"or statements made by, third parties in respect of the information in {PROTOCOL} Playgrounds."
+    )
+]
+
+
+def short_disclaimer_row():
+    return dbc.Row([
+        dbc.Card([
+            dbc.CardBody([
+                html.Div([
+                    html.H4("Disclaimer"),
+                    html.P(SHORT_DISCLAIMER)
+                ])
+            ])
+        ])
+    ])
+
+
+def long_disclaimer_row():
+    return dbc.Row([
+        dbc.Card([
+            dbc.CardBody([
+                html.Div([
+                    html.H1("Disclaimer"),
+                    html.Div(LONG_DISCLAIMER)
+                ])
+            ])
+        ])
+    ])

--- a/config.py
+++ b/config.py
@@ -1,0 +1,1 @@
+PROTOCOL = "Klima"

--- a/index.py
+++ b/index.py
@@ -3,7 +3,9 @@ import dash_bootstrap_components as dbc
 from dash import html
 from dash.dependencies import Input, Output
 from app import app
-from apps import playgroundSimulation_KlimaGrowthOverTime, playgroundsSimulation_KlimaBonding, homePage
+from apps import playgroundSimulation_KlimaGrowthOverTime, \
+                 playgroundsSimulation_KlimaBonding, \
+                 homePage, disclaimerPage
 
 SIDEBAR_STYLE = {
     "position": "fixed",
@@ -34,7 +36,8 @@ navbar = dbc.NavbarSimple(
                 dbc.DropdownMenuItem("More pages", header=True),
                 dbc.DropdownMenuItem("KlimaDAO", href="https://www.klimadao.finance/#/stake"),
                 dbc.DropdownMenuItem("Learn More", href="https://docs.klimadao.finance/"),
-                dbc.DropdownMenuItem("Feedback", href="https://forms.gle/UTyj7HvCfBNa1rt17")
+                dbc.DropdownMenuItem("Feedback", href="https://forms.gle/UTyj7HvCfBNa1rt17"),
+                dbc.DropdownMenuItem("Disclaimer", href="/disclaimer")
             ],
             nav=True,
             in_navbar=True,
@@ -63,6 +66,8 @@ def display_page(pathname):
         return playgroundSimulation_KlimaGrowthOverTime.layout
     elif pathname == '/apps/playgroundsSimulation_KlimaBonding':
         return playgroundsSimulation_KlimaBonding.layout
+    elif pathname == '/disclaimer':
+        return disclaimerPage.layout
     else:
         return homePage.layout
 
@@ -72,4 +77,4 @@ server = app.server
 
 
 if __name__ == '__main__':
-    app.run_server(debug=True)
+    app.run_server(debug=True, host='0.0.0.0')

--- a/tachiNotes.txt
+++ b/tachiNotes.txt
@@ -1,1 +1,0 @@
-Testing connection to the git


### PR DESCRIPTION
Add the same disclaimer used on current Olympus PoC, with short form appearing on all pages and long form linked from the dropdown menu

The only issue is that the width of the disclaimer row doesn't match the rows above - I think this is just a padding issue that can easily be sorted out

<img width="1260" alt="Screen Shot 2021-12-09 at 10 39 22 PM" src="https://user-images.githubusercontent.com/91024694/145513358-17e67705-84e4-45d8-9b02-ee1da43fb0bf.png">
 