### PR TITLE
Fix/deps versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pandas==1.3.4
 requests
 retrying
 pycoingecko
-dash-extensions
 
 subgrounds==0.1.1
 plotly~=5.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ansi2html
-dash==2.0.0
-dash-bootstrap-components==1.0.0
+dash==2.3.1
+dash-bootstrap-components==1.1.0
+dash-extensions==0.1.1
 gunicorn
 lottie
 millify~=0.1.1
@@ -10,7 +11,7 @@ retrying
 pycoingecko
 dash-extensions
 
-subgrounds~=0.0.8
-plotly~=5.6.0
+subgrounds==0.1.1
+plotly~=5.7.0
 numpy~=1.22.3
-Werkzeug==2.0.3
+Werkzeug==2.1.2


### PR DESCRIPTION
- Bump `subgrounds` version from `0.0.8` to `0.1.1`
- Bump `dash` version from `2.0.0` to `2.3.1`
- Bump `dash-bootstrap-components` version from `1.0.0` to `1.1.0`
- Bump `plotly` version from `5.6.0` to `5.7.0`
- Bump `Werkzeug` version from `2.0.3` to `2.1.2`
- Add `dash-extensions`